### PR TITLE
Correct variable name

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -82,7 +82,7 @@ class SkillTesting(MycroftSkill):
     def detect_handler(self, m):
         tick = time.time()
         handler_message_data = json.loads(m.serialize())['data']
-        self.log.debug('Detected Skill handler: {}'.format(message_data))
+        self.log.debug('Detected Skill handler: {}'.format(handler_message_data))
         keys = handler_message_data.keys()
         # Normal Skills
         if 'name' in keys:


### PR DESCRIPTION
```
2019-09-13 21:49:33.656 | DEBUG    |   948 | SkillTesting | Detected spoken response: {'expect_response': False, 'utterance': 'An error occurred while processing a request in Skill Testing'}
2019-09-13 21:49:33.764 | ERROR    |   948 | mycroft.skills.mycroft_skill.mycroft_skill:on_error:681 | An error occurred while processing a request in Skill Testing
Traceback (most recent call last):
  File "/home/pi/mycroft-core/mycroft/skills/mycroft_skill/event_container.py", line 66, in wrapper
    handler(message)
  File "/opt/mycroft/skills/skill-testing-skill.krisgesling/__init__.py", line 85, in detect_handler
    self.log.debug('Detected Skill handler: {}'.format(message_data))
NameError: name 'message_data' is not defined
2019-09-13 21:49:33.815 | ERROR    |   948 | mycroft.skills.mycroft_skill.mycroft_skill:on_error:681 | An error occurred while processing a request in Skill Testing
Traceback (most recent call last):
  File "/home/pi/mycroft-core/mycroft/skills/mycroft_skill/event_container.py", line 66, in wrapper
    handler(message)
  File "/opt/mycroft/skills/skill-testing-skill.krisgesling/__init__.py", line 85, in detect_handler
    self.log.debug('Detected Skill handler: {}'.format(message_data))
NameError: name 'message_data' is not defined
```